### PR TITLE
Renaming Angular2 to Angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # ng2wig
-Angular2 WYSIWYG editor (from ngWig)
+Angular WYSIWYG editor (from ngWig)

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,3 @@
-<h1>NgWig Demo</h1>
+<h1>NgWig Angular Demo</h1>
 <ng-wig></ng-wig>
 


### PR DESCRIPTION
Rename according to [Angular Press Kit](https://angular.io/presskit.html)